### PR TITLE
Multiline decode

### DIFF
--- a/src/main/clojure/cemerick/rummage/encoding.clj
+++ b/src/main/clojure/cemerick/rummage/encoding.clj
@@ -46,7 +46,7 @@
 (defn from-prefixed-string
   "Reproduces the representation of the item from a string created by to-prefixed-string"
   ([formatting ^String s]
-    (let [[[_ prefix value-str]] (re-seq #"([^:]+):(.*)" s)]
+    (let [[[_ prefix value-str]] (re-seq #"(?s)([^:]+):(.*)" s)]
       (when (not prefix)
         (throw (IllegalArgumentException.
                  (format "Cannot decode (%s...), no prefix found"

--- a/src/test/clojure/cemerick/rummage/encoding_test.clj
+++ b/src/test/clojure/cemerick/rummage/encoding_test.clj
@@ -48,7 +48,8 @@
     (Date.) (URL. "http://clojure.org"))
   
   (roundtrip (enc/all-prefixed-config)
-    ["name" "a"] [42 42]
+    ["name" "a"] ["multiline" "one\ntwo\nthree\n\nfour"]
+    [42 42]
     [false true] [99.2 108.6]
     [(URL. "http://clojure.org") (URL. "http://clojure.org")]
     [(Date.) (Date.)]))


### PR DESCRIPTION
Regex to match the body of a prefixed value will now match across line endings. Fixes issue #7.
