### PR TITLE
Skipping integration tests when 'maven.test.skip' is specified

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,60 @@
         <clojure.version>1.4.0</clojure.version>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>with-tests</id>
+            <activation>
+                <property>
+                    <name>!maven.test.skip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.theoryinpractise</groupId>
+                        <artifactId>clojure-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>clojure-test</id>
+                                <configuration>
+                                    <clojureOptions>-Daws.id=${aws.id} -Daws.secret-key=${aws.secret-key}</clojureOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <warnOnReflection>true</warnOnReflection>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.5</version>
+                        <configuration>
+                            <projectsDirectory>src/integration</projectsDirectory>
+                            <cloneProjectsTo>${project.build.directory}/integration</cloneProjectsTo>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <streamLogs>true</streamLogs>
+                            <localRepositoryPath>it-repo</localRepositoryPath>
+                            <goals><goal>clojure:test</goal></goals>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -44,50 +98,5 @@
             <version>0.0.2</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.theoryinpractise</groupId>
-                <artifactId>clojure-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>clojure-test</id>
-                        <configuration>
-                            <clojureOptions>-Daws.id=${aws.id} -Daws.secret-key=${aws.secret-key}</clojureOptions>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <warnOnReflection>true</warnOnReflection>
-                </configuration>
-            </plugin>
-            
-            <plugin>
-                <artifactId>maven-invoker-plugin</artifactId>
-                <version>1.5</version>
-                <configuration>
-                    <projectsDirectory>src/integration</projectsDirectory>
-                    <cloneProjectsTo>${project.build.directory}/integration</cloneProjectsTo>
-                    <pomIncludes>
-                        <pomInclude>*/pom.xml</pomInclude>
-                    </pomIncludes>
-                    <streamLogs>true</streamLogs>
-                    <localRepositoryPath>it-repo</localRepositoryPath>
-                    <goals><goal>clojure:test</goal></goals>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>integration-test</id>
-                        <goals>
-                            <goal>install</goal>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            
-        </plugins>
-    </build>
 
 </project>


### PR DESCRIPTION
Since the executions of clojure-maven-plugin and maven-invoker-plugin do not honor the "maven.test.skip" property, specifying this still causes tests to execute.

This commit moves those executions into a profile which is activated if the skip property is not set.
